### PR TITLE
Add compatibility with commonjs and browserify

### DIFF
--- a/doc-ready.js
+++ b/doc-ready.js
@@ -62,9 +62,11 @@ if ( typeof define === 'function' && define.amd ) {
   // if RequireJS, then doc is already ready
   docReady.isReady = typeof requirejs === 'function';
   define( [ 'eventie/eventie' ], defineDocReady );
+} else if ( typeof exports === 'object' ) {
+  module.exports = defineDocReady( require('eventie') );
 } else {
   // browser global
   window.docReady = defineDocReady( window.eventie );
 }
 
-})( this );
+})( window );

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "doc-ready",
+  "version": "1.0.2",
+  "description": "Cross browser document ready helper. Supported by IE8+ and good browsers.",
+  "main": "doc-ready.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/desandro/doc-ready.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/desandro/doc-ready/issues"
+  },
+  "homepage": "https://github.com/desandro/doc-ready",
+  "dependencies": {
+    "eventie": "https://github.com/wbinnssmith/eventie/archive/commonjs.tar.gz"
+  }
+}


### PR DESCRIPTION
Adds a commonjs export and package.json so this can be packaged with commonjs bundlers. Had to move `this` in the wrapper call to `window` since `this` is the current module in cjs environments.

If [eventie#3](https://github.com/desandro/eventie/pull/3) gets merged I can move the package json dependency to desandro/eventie
